### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -286,7 +286,7 @@ version 0.0.1 (10/04/2013)
 .. |coverage| image:: https://coveralls.io/repos/provoke-vagueness/restq/badge.png?branch=master
    :target: https://coveralls.io/r/provoke-vagueness/restq?branch=master
    :alt: Latest PyPI version
-.. |pypi_version| image:: https://pypip.in/v/restq/badge.png
+.. |pypi_version| image:: https://img.shields.io/pypi/v/restq.svg
    :target: https://crate.io/packages/restq/
    :alt: Latest PyPI version
 .. |build_status| image:: https://secure.travis-ci.org/provoke-vagueness/restq.png?branch=master


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20restq))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `restq`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.