### PR TITLE
Treat all queue names as strings to avoid JSON confusion

### DIFF
--- a/restq/realms.py
+++ b/restq/realms.py
@@ -170,6 +170,9 @@ class Realm:
                         (job_id)
                 raise ValueError(msg)
 
+        # Enforce that queue_id is a string, due to JSON constraints
+        queue_id = str(queue_id)
+
         # update the job's queue record
         job[JOB_QUEUES].add(queue_id)
 
@@ -215,7 +218,7 @@ class Realm:
     @serialise
     def clear_queue(self, queue_id):
         """remove all jobs from the given queue"""
-        queue = self.queues.get(queue_id, None)
+        queue = self.queues.get(str(queue_id), None)
         if queue is None:
             raise ValueError("Queue '%s' does not exist" % queue_id)
 
@@ -266,6 +269,8 @@ class Realm:
         self._save_config()
 
     def _set_queue_lease_time(self, queue_id, lease_time):
+        # Enforce queue to be a string due to JSON constraints
+        queue_id = str(queue_id)
         queue = self.queues.get(queue_id, None)
         if queue is None:
             self._create_queue(queue_id, lease_time)
@@ -294,6 +299,8 @@ class Realm:
             yaml.dump(realm_config, f, default_flow_style=False)
 
     def _create_queue(self, queue_id, lease_time):
+        # Enforce that queue names are string, due to JSON constraints on dicts
+        queue_id = str(queue_id)
         queue = OrderedDict()
         self.queues[queue_id] = queue
         self.queue_lease_time[queue_id] = lease_time

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,8 @@ class TestApi(unittest.TestCase):
             self.assertEquals(resp.status_int, 200)
             body = json.loads(str(resp.body))
             for k,v in body.iteritems():
-                self.assertEquals([1, int(k)], v)
+                # Queue ID should have been converted to a string
+                self.assertEquals(['1', int(k)], v)
 
             #remove the job
             resp = self.app.delete("/realm/job/%d" % i)
@@ -42,7 +43,7 @@ class TestApi(unittest.TestCase):
         self.assertEquals(resp.status_int, 200)
         body = json.loads(resp.body)
         for k,v in body.iteritems():
-            self.assertEquals([1,int(k)], v)
+            self.assertEquals(['1',int(k)], v)
 
         #remove the remaining jobs
         for i in range(50, 100):


### PR DESCRIPTION
restq passes or returns queue IDs in JSON mappings (dicts) at a few points. JSON doesn't support numeric indexes in dicts, so the client has no way to know if the original queue ID was a string or an integer.
If the client calls /&lt;realm&gt;/status and sees a queue called str("1"), and then asks to set queue lease time for queue str("1"), but the server actually has a queue called int(1), then the server will create a NEW queue called str("1") and set the lease time on that. The server now has two queues, called int(1) and str("1"), which is both confusing, and also breaks the JSON when you call status again (you get '`"queues": {"1": {}, "1": {}}`').

This patch converts queue_id to str every time it is passed into the core functions of realms.py, with the result that queue IDs will now always be the string representation of whatever you pass in, and will be valid JSON keys.